### PR TITLE
Optional stdout/stderr silence

### DIFF
--- a/postgres-embedded.cabal
+++ b/postgres-embedded.cabal
@@ -27,6 +27,7 @@ library
   other-modules:       Database.PostgreSQL.Embedded.Postgres
                      , Database.PostgreSQL.Embedded.Download
                      , Database.PostgreSQL.Embedded.Types
+                     , Database.PostgreSQL.Embedded.Exec
   build-depends:       base >= 4 && < 5
                      , directory
                      , filepath

--- a/src/Database/PostgreSQL/Embedded/Exec.hs
+++ b/src/Database/PostgreSQL/Embedded/Exec.hs
@@ -1,0 +1,37 @@
+module Database.PostgreSQL.Embedded.Exec
+  ( systemSilent
+  , rawSystemSilent
+  ) where
+
+import           GHC.IO.Exception (IOErrorType (..), ioException)
+import           System.Exit
+import           System.IO
+import           System.IO.Error
+import           System.Process
+
+{-|
+Exactly like 'System.Process.system' but does not capture stdout nor stderr.
+-}
+systemSilent :: String -> IO ExitCode
+systemSilent "" = ioException (ioeSetErrorString (mkIOError InvalidArgument "system" Nothing Nothing) "null command")
+systemSilent str = do
+  devNull <- openFile "/dev/null" WriteMode
+  (_, _, _, p) <- createProcess_ "system" (shell str) {delegate_ctlc = True, std_err = UseHandle devNull, std_out = UseHandle devNull}
+  waitForProcess p
+
+{-|
+Exactly like 'System.Process.rawSystem' but does not capture stdout nor stderr.
+-}
+rawSystemSilent :: String -> [String] -> IO ExitCode
+rawSystemSilent cmd args = do
+  devNull <- nullDevice
+  (_, _, _, p) <- createProcess_ "rawSystem" (proc cmd args) {delegate_ctlc = True, std_err = UseHandle devNull, std_out = UseHandle devNull}
+  waitForProcess p
+
+nullDevice :: IO Handle
+nullDevice = do
+  h <- tryIOError nix
+  either (const windows) pure h
+  where
+    nix = openFile "/dev/null" WriteMode
+    windows = openFile "nul" WriteMode

--- a/src/Database/PostgreSQL/Embedded/Types.hs
+++ b/src/Database/PostgreSQL/Embedded/Types.hs
@@ -21,6 +21,8 @@ data StartupConfig = StartupConfig
       cleanDir :: Bool
       -- | See @Version@
     , version  :: Version
+      -- | Silence the output of PG commands
+    , silent   :: Bool
     }
 
 -- | Config of running instance
@@ -29,6 +31,7 @@ data RuntimeConfig = RuntimeConfig
       execDir :: FilePath
       -- | Data directory
     , dataDir :: FilePath
+    , silentR :: Bool
     }
 
 -- | Database config

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,7 +10,7 @@ import           Database.PostgreSQL.Embedded
 
 main :: IO ()
 main = do
-    let sConfig = StartupConfig True (Version "9.6.5-1")
+    let sConfig = StartupConfig True (Version "9.6.5-1") False
     let dConfig = DBConfig 46782 "postgres"
 
     system $ "rm" <> " -rf " <> ("~/.postgres-embedded/" </> "9.6.5-1")


### PR DESCRIPTION
Hello,

I've made this small change in which the user can optionally silence the verbose output of `wget` and the postgres start-up scripts. It's useful in decluttering my test code output in which I'm using this neat little library.

I'm eager to have this merged in your next release and I'm willing to do any changes you see are necessary :smiley:.