### PR TITLE
Use 'mingw32' to detect Windows

### DIFF
--- a/src/Database/PostgreSQL/Embedded/Postgres.hs
+++ b/src/Database/PostgreSQL/Embedded/Postgres.hs
@@ -45,7 +45,7 @@ startPostgres (StartupConfig сlean version_ silent_) dConfig@(DBConfig p u) = d
     where
         getOS | "darwin" `isInfixOf` os = OSX
               | "linux" `isInfixOf` os = Linux
-              | "win" `isInfixOf` os = Win
+              | "mingw32" `isInfixOf` os = Win
               | otherwise = error $ "Unsupported platform" <> os
 
 {-|


### PR DESCRIPTION
Otherwise tests fail with 'postgres-embedded-test.exe: Unsupported platformmingw32'